### PR TITLE
feat(gui_list_all): add sway inventory support

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,7 +23,7 @@ read_globals = {
     "vector",
 
     "flow", "logging", "settings_loader", "modlib",
-    "unified_inventory",
+    "unified_inventory", "sway",
 
     table = {
         fields = {

--- a/teacher_core/mod.conf
+++ b/teacher_core/mod.conf
@@ -1,4 +1,4 @@
 name = teacher_core
 depends = settings_loader, flow, logging, modlib
-optional_depends = unified_inventory
+optional_depends = unified_inventory, sway
 supported_games = *

--- a/teacher_core/src/gui_list_all.lua
+++ b/teacher_core/src/gui_list_all.lua
@@ -251,8 +251,8 @@ if minetest.global_exists("unified_inventory") then
     })
 end
 if minetest.global_exists("sway") then
-    local pagename = "teacher_core:teacher_show_all"
-    sway.register_page(pagename, {
+    local pagename = "teacher_show_all"
+    sway.register_page("teacher_core:"..pagename, {
         title = S("Tutorials"),
         get = function(_self, player, ctx)
             if not ctx[pagename] then

--- a/teacher_core/src/gui_list_all.lua
+++ b/teacher_core/src/gui_list_all.lua
@@ -173,7 +173,7 @@ teacher.gui_list_all = flow.make_gui(function(player, ctx)
                 label = S("All Tutorials"),
                 expand = true, align_h = "left",
             },
-            gui.ButtonExit {
+            ctx.inside_sway and gui.Nil{} or gui.ButtonExit {
                 w = 0.3, h = 0.3,
                 label = "x",
             },
@@ -248,5 +248,22 @@ if minetest.global_exists("unified_inventory") then
         action = function(player)
             teacher.show_all(player)
         end,
+    })
+end
+if minetest.global_exists("sway") then
+    local pagename = "teacher_core:teacher_show_all"
+    sway.register_page(pagename, {
+        title = S("Tutorials"),
+        get = function(_self, player, ctx)
+            if not ctx[pagename] then
+                ctx[pagename] = { inside_sway = true }
+            end
+            return sway.Form {
+                teacher.gui_list_all:embed {
+                    player = player,
+                    name = pagename
+                }
+            }
+        end
     })
 end


### PR DESCRIPTION
Adds an inventory tab to sway, much like how it already adds a button to unified inventory.

Since (in this case) it is embedding the form instead of replacing it, we are using the flow `embed` function to intelligently attach a prefix to all unique names - to prevent namespace collisions.

I'm also hiding the close button, since the button doesn't make sense in an embedded context.

Tested and verified to function with several other mods that modify sway forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Registered a new page for displaying all teacher resources within the application. _Note from @Lazerbeak12345 : "inventory" is a more prudent word than "application"_
  
- **Improvements**
	- Introduced dynamic visibility of the exit button based on the application context, improving user experience. _Note from @Lazerbeak12345 : more accurate to say that it's based on if it's inside of sway or not_

- **Dependencies**
	- Added "sway" as an optional dependency for the teacher_core module to enhance functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->